### PR TITLE
Improve portability and robustness

### DIFF
--- a/tests/unit/test_auto_switch_cache.bats
+++ b/tests/unit/test_auto_switch_cache.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+
+load '../helpers/test_helper'
+
+setup() {
+    setup_test_environment
+    ORIGINAL_PATH="$PATH"
+    AUTO_SWITCH_CACHE_DIR="$TEST_HOME/cache"
+}
+
+teardown() {
+    PATH="$ORIGINAL_PATH"
+    cleanup_test_environment
+}
+
+create_stub_bin_dir() {
+    local dir="$BATS_TEST_TMPDIR/fake_bin_$BATS_TEST_NAME"
+    mkdir -p "$dir"
+    echo "$dir"
+}
+
+@test "auto-switch cache uses sha256sum when available" {
+    local fake_bin
+    fake_bin=$(create_stub_bin_dir)
+
+    cat > "$fake_bin/sha256sum" <<'EOF'
+#!/usr/bin/env bash
+input=$(cat)
+printf '%s' "$input" > "${BATS_TEST_TMPDIR}/sha256sum_called"
+crc=$(printf '%s' "$input" | cksum | awk '{print $1}')
+printf '%08x%08x  -\n' "$((10#$crc % 0x100000000))" "${#input}"
+EOF
+    chmod +x "$fake_bin/sha256sum"
+
+    PATH="$fake_bin:$ORIGINAL_PATH"
+
+    local path="/tmp/test path"
+    local cache_path
+    cache_path=$(auto_switch_cache_file "$path")
+
+    [[ -f "${BATS_TEST_TMPDIR}/sha256sum_called" ]]
+    local expected_hash
+    expected_hash=$(auto_switch_hash "$path")
+    [[ "$cache_path" == "$AUTO_SWITCH_CACHE_DIR/path-$expected_hash" ]]
+}
+
+@test "auto-switch cache falls back to shasum when sha256sum fails" {
+    local fake_bin
+    fake_bin=$(create_stub_bin_dir)
+
+    cat > "$fake_bin/sha256sum" <<'EOF'
+#!/usr/bin/env bash
+printf '%s' "$@" > "${BATS_TEST_TMPDIR}/sha256sum_invoked"
+exit 1
+EOF
+    chmod +x "$fake_bin/sha256sum"
+
+    cat > "$fake_bin/shasum" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" != "-a" || "$2" != "256" ]]; then
+  exit 2
+fi
+shift 2
+input=$(cat)
+printf '%s' "$input" > "${BATS_TEST_TMPDIR}/shasum_called"
+crc=$(printf '%s' "$input" | cksum | awk '{print $1}')
+printf '%08x%08x  -\n' "$((10#$crc % 0x100000000))" "${#input}"
+EOF
+    chmod +x "$fake_bin/shasum"
+
+    PATH="$fake_bin:$ORIGINAL_PATH"
+
+    local path="/tmp/fallback test"
+    local cache_path
+    cache_path=$(auto_switch_cache_file "$path")
+
+    [[ -f "${BATS_TEST_TMPDIR}/sha256sum_invoked" ]]
+    [[ -f "${BATS_TEST_TMPDIR}/shasum_called" ]]
+
+    local expected_hash
+    expected_hash=$(auto_switch_hash "$path")
+    [[ "$cache_path" == "$AUTO_SWITCH_CACHE_DIR/path-$expected_hash" ]]
+}
+
+@test "auto-switch cache uses internal fallback when external tools unavailable" {
+    local fake_bin
+    fake_bin=$(create_stub_bin_dir)
+
+    for cmd in sha256sum shasum openssl python3 python; do
+        cat > "$fake_bin/$cmd" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+        chmod +x "$fake_bin/$cmd"
+    done
+
+    PATH="$fake_bin:$ORIGINAL_PATH"
+
+    local path="/tmp/internal fallback"
+    local cache_hash
+    cache_hash=$(auto_switch_hash "$path")
+    local fallback_hash
+    fallback_hash=$(auto_switch_hash_fallback "$path")
+
+    [[ "$cache_hash" == "$fallback_hash" ]]
+    [[ "$cache_hash" =~ ^[0-9a-f]{16}$ ]]
+}


### PR DESCRIPTION
## Summary
- Added portable hashing fallbacks so auto-switch cache works even without sha256sum
- Reused centralized SSH key validation to fix macOS permission warnings
- Hardened project assignment updates against regex metacharacters and expanded coverage

## Testing
- npm run test:unit
- npm run ci-check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds portable auto-switch cache hashing, hardens path-based/project assignments against regex pitfalls, and centralizes cross-platform SSH key permission checks.
> 
> - **Core (`gh-switcher.sh`)**:
>   - **Auto-switch cache**: Introduces `auto_switch_hash` with multi-tool fallbacks (`sha256sum`, `shasum`, `openssl`, `python3/python`, CRC fallback) and updates cache key generation.
>   - **SSH**: Adds `file_get_permissions` and refactors `validate_ssh_key` for cross-platform perms (Darwin/msys), proper octal handling, and clearer fix flows.
>   - **Project assignments**:
>     - Replace `grep`-based edits with line-iterative logic to avoid regex issues; use `printf` for safe writes.
>     - Update `project_assign`, `project_assign_path`, and `cmd_assign_remove` to correctly match and remove entries (including escaped pipes).
> - **Tests**:
>   - New unit tests for cache hashing fallbacks and behavior.
>   - New integration test ensuring directories with regex metacharacters are handled.
>   - Adds macOS-secure SSH key permissions test; minor grep fixes (`-Fq`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4f1f20cc6caaa28e9cb7a6be21904c2da7612b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->